### PR TITLE
Bind event api tweaks

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/src/App.js
+++ b/src/App.js
@@ -9,19 +9,21 @@ import { PageBoundary } from './components/analytics';
 class App extends Component {
   render() {
     return (
-      <AnalyticsListener
-        channel="atlaskit"
-        onEvent={event => console.log('Received Atlaskit event:', event)}
-      >
+      <AnalyticsListener onEvent={event => console.log('Received event:', event)}>
         <AnalyticsListener
-          channel="jira"
-          onEvent={event => console.log('Received Jira event:', event)}
+          channel="atlaskit"
+          onEvent={event => console.log('Received Atlaskit event:', event)}
         >
-          <PageBoundary analyticsNamespace="backlog">
-            <div style={{ padding: '40px' }}>
-              <Issue analyticsNamespace="issue" issueId={123} />
-            </div>
-          </PageBoundary>
+          <AnalyticsListener
+            channel="jira"
+            onEvent={event => console.log('Received Jira event:', event)}
+          >
+            <PageBoundary analyticsNamespace="backlog">
+              <div style={{ padding: '40px' }}>
+                <Issue analyticsNamespace="issue" issueId={123} />
+              </div>
+            </PageBoundary>
+          </AnalyticsListener>
         </AnalyticsListener>
       </AnalyticsListener>
     );

--- a/src/components/Issue.js
+++ b/src/components/Issue.js
@@ -2,11 +2,11 @@
 
 import React, { Component } from 'react';
 
-import { AnalyticsBoundary, withAnalytics } from '../modules/analytics';
+import { AnalyticsBoundary } from '../modules/analytics';
 
 import UserSelect from './UserSelect';
 
-class Issue extends Component {
+export default class Issue extends Component<*> {
   state = {
     assignee: null,
     reporter: null,
@@ -67,5 +67,3 @@ class Issue extends Component {
     );
   }
 }
-
-export default withAnalytics(Issue);

--- a/src/components/Issue.js
+++ b/src/components/Issue.js
@@ -58,6 +58,7 @@ class Issue extends Component {
           <UserSelect
             analytics={{ select: 'reporter-change' }}
             analyticsNamespace="reporter-select"
+            useEventCallbackButton
             value={this.state.reporter}
             onChange={this.onReporterChange}
           />

--- a/src/components/Issue.js
+++ b/src/components/Issue.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { AnalyticsBoundary } from '../modules/analytics';
 
 import UserSelect from './UserSelect';
+import { ButtonFireOnly } from '../modules/button';
 
 export default class Issue extends Component<*> {
   state = {
@@ -63,6 +64,8 @@ export default class Issue extends Component<*> {
             onChange={this.onReporterChange}
           />
         </div>
+        <h3>Button that creates & fires straight away</h3>
+        <ButtonFireOnly onClick={() => 'a'} >Fire</ButtonFireOnly>
       </AnalyticsBoundary>
     );
   }

--- a/src/components/UserSelect.js
+++ b/src/components/UserSelect.js
@@ -4,11 +4,11 @@ import React, { Component } from 'react';
 
 import { withAnalytics } from '../modules/analytics';
 import Button, { ButtonWithCreateEventCallback } from '../modules/button';
-import { type withAnalyticsProps } from '../modules/analytics/withAnalytics';
+import Checkbox from '../modules/checkbox';
 
-type Props = withAnalyticsProps & {
+type Props = {
   value: string,
-  useEventCallbackButton: boolean,
+  useEventCallbackButton?: boolean,
   onChange: (user: string) => void,
 };
 
@@ -41,11 +41,6 @@ class UserSelect extends Component<Props, State> {
   onCheckboxChange = () => {
     const isCheckboxChecked = !this.state.isCheckboxChecked;
     this.setState({ isCheckboxChecked });
-
-    this.props.createAnalyticsEvent(
-      'checkbox-change',
-      { checked: isCheckboxChecked }
-    ).raise();
   }
 
   render() {
@@ -71,8 +66,8 @@ class UserSelect extends Component<Props, State> {
           ))}
           <p>
             <label>
-              <input
-                type="checkbox"
+              <Checkbox
+                analytics={{ checked: 'checkbox-change' }}
                 onChange={this.onCheckboxChange}
                 checked={this.state.isCheckboxChecked}
               />
@@ -85,4 +80,4 @@ class UserSelect extends Component<Props, State> {
   }
 }
 
-export default withAnalytics(UserSelect);
+export default withAnalytics()(UserSelect);

--- a/src/components/UserSelect.js
+++ b/src/components/UserSelect.js
@@ -4,10 +4,18 @@ import React, { Component } from 'react';
 
 import { withAnalytics } from '../modules/analytics';
 import Button from '../modules/button';
+import { type withAnalyticsProps } from '../modules/analytics/withAnalytics';
 
-const BoundButton = withAnalytics(Button, { click: 'onClick' });
+type Props = withAnalyticsProps & {
+  value: string,
+  onChange: (user: string) => void,
+};
 
-class UserSelect extends Component {
+type State = {
+  isCheckboxChecked: boolean,
+}
+
+class UserSelect extends Component<Props, State> {
   state = {
     isCheckboxChecked: false,
   }
@@ -44,14 +52,15 @@ class UserSelect extends Component {
         <p>Selected user: {value || 'none'}</p>
         <div>
           {USERS.map(name => (
-            <BoundButton
+            <Button
               analyticsNamespace="button"
+              bindEventsToProps={{click: 'onClick' }}
               key={name}
               onClick={(event, analyticsEvent) =>
                 this.handleClick(name, analyticsEvent)}
             >
               {name}
-            </BoundButton>
+            </Button>
           ))}
           <p>
             <label>

--- a/src/components/UserSelect.js
+++ b/src/components/UserSelect.js
@@ -3,11 +3,12 @@
 import React, { Component } from 'react';
 
 import { withAnalytics } from '../modules/analytics';
-import Button from '../modules/button';
+import Button, { ButtonWithCreateEventCallback } from '../modules/button';
 import { type withAnalyticsProps } from '../modules/analytics/withAnalytics';
 
 type Props = withAnalyticsProps & {
   value: string,
+  useEventCallbackButton: boolean,
   onChange: (user: string) => void,
 };
 
@@ -16,6 +17,10 @@ type State = {
 }
 
 class UserSelect extends Component<Props, State> {
+  defaultProps = {
+    useEventCallbackButton: false,
+  }
+
   state = {
     isCheckboxChecked: false,
   }
@@ -44,15 +49,17 @@ class UserSelect extends Component<Props, State> {
   }
 
   render() {
-    const { value } = this.props;
+    const { value, useEventCallbackButton } = this.props;
     const USERS = ['Jed', 'Michael', 'Jared'];
+
+    const ButtonType = useEventCallbackButton ? ButtonWithCreateEventCallback : Button;
 
     return (
       <div>
         <p>Selected user: {value || 'none'}</p>
         <div>
           {USERS.map(name => (
-            <Button
+            <ButtonType
               analyticsNamespace="button"
               bindEventsToProps={{click: 'onClick' }}
               key={name}
@@ -60,7 +67,7 @@ class UserSelect extends Component<Props, State> {
                 this.handleClick(name, analyticsEvent)}
             >
               {name}
-            </Button>
+            </ButtonType>
           ))}
           <p>
             <label>

--- a/src/components/analytics/Namespace.js
+++ b/src/components/analytics/Namespace.js
@@ -1,14 +1,14 @@
 // @flow
 
-import { Component } from 'react';
+import React, { Component } from 'react';
 
 import { withAnalytics } from '../../modules/analytics';
 
 /** A convenience component which allows you to drop a new analyticsNamespace
  * layer in the page without having to wrap anything in withAnalytics. */
-class Namespace extends Component {
+class Namespace extends Component<*> {
   render() {
-    return this.props.children;
+    return React.Children.only(this.props.children);
   }
 }
 

--- a/src/components/analytics/Namespace.js
+++ b/src/components/analytics/Namespace.js
@@ -12,4 +12,4 @@ class Namespace extends Component {
   }
 }
 
-export default withAnalytics(Namespace);
+export default withAnalytics()(Namespace);

--- a/src/components/analytics/PageBoundary.js
+++ b/src/components/analytics/PageBoundary.js
@@ -7,13 +7,15 @@ import ViewTracker from './ViewTracker';
 
 /** A convenience component which combines a Namespace and a ViewTracker. Useful
  * for declaring 'page boundaries'. */
-export default class PageBoundary extends Component {
+export default class PageBoundary extends Component<*> {
   render() {
     const { analyticsNamespace, children } = this.props;
     return (
       <Namespace analyticsNamespace={analyticsNamespace}>
-        <ViewTracker page={analyticsNamespace} />
-        {children}
+        <div>
+          <ViewTracker page={analyticsNamespace} />
+          {children}
+        </div>
       </Namespace>
     );
   }

--- a/src/components/analytics/ViewTracker.js
+++ b/src/components/analytics/ViewTracker.js
@@ -15,4 +15,4 @@ class ViewTracker extends Component {
   render() { return null; }
 }
 
-export default withAnalytics(ViewTracker);
+export default withAnalytics()(ViewTracker);

--- a/src/modules/analytics/AnalyticsBoundary.js
+++ b/src/modules/analytics/AnalyticsBoundary.js
@@ -3,7 +3,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
-export default class AnalyticsBoundary extends Component {
+export default class AnalyticsBoundary extends Component<*> {
   static childContextTypes = {
     raiseAnalyticsEvent: PropTypes.func,
   }

--- a/src/modules/analytics/AnalyticsEvent.js
+++ b/src/modules/analytics/AnalyticsEvent.js
@@ -1,7 +1,18 @@
 // @flow
 
+export type noop = (...args: any) => {};
+export type FireAnalyticsEvent = (event: AnalyticsEvent, channel: string) => void | noop;
+export type RaiseAnalyticsEvent = (event: AnalyticsEvent) => void;
+export type EventEnhancer = (payload: {}) => {} | {};
+
 export default class AnalyticsEvent {
-  constructor(name, payload, meta, { fire: fireCallback, raise: raiseCallback }) {
+  name: string;
+  payload: {};
+  meta: {};
+  fireCallback: FireAnalyticsEvent;
+  raiseCallback: RaiseAnalyticsEvent;
+
+  constructor(name: string, payload: {}, meta: {}, { fire: fireCallback, raise: raiseCallback }: { fire: FireAnalyticsEvent, raise: RaiseAnalyticsEvent}) {
     this.name = name;
     this.payload = payload;
     this.meta = meta;
@@ -9,12 +20,12 @@ export default class AnalyticsEvent {
     this.raiseCallback = raiseCallback;
   }
 
-  rename = name => {
+  rename = (name: string) => {
     this.name = name;
     return this;
   }
 
-  enhance = enhancer => {
+  enhance = (enhancer: EventEnhancer) => {
     if (typeof enhancer === 'function') {
       this.payload = enhancer(this.payload);
     }
@@ -30,7 +41,7 @@ export default class AnalyticsEvent {
     return this;
   }
 
-  fire = channel => {
+  fire = (channel: string) => {
     this.fireCallback(this, channel);
     return this;
   }

--- a/src/modules/analytics/AnalyticsEvent.js
+++ b/src/modules/analytics/AnalyticsEvent.js
@@ -1,9 +1,8 @@
 // @flow
 
-export type noop = (...args: any) => {};
-export type FireAnalyticsEvent = (event: AnalyticsEvent, channel: string) => void | noop;
+export type FireAnalyticsEvent = (event: AnalyticsEvent, channel?: string) => void;
 export type RaiseAnalyticsEvent = (event: AnalyticsEvent) => void;
-export type EventEnhancer = (payload: {}) => {} | {};
+export type EventEnhancer = ((payload: {}) => {}) | {};
 
 export default class AnalyticsEvent {
   name: string;
@@ -41,13 +40,11 @@ export default class AnalyticsEvent {
     return this;
   }
 
-  fire = (channel: string) => {
+  fire = (channel?: string) => {
     this.fireCallback(this, channel);
-    return this;
   }
 
   raise = () => {
     this.raiseCallback(this);
-    return this;
   }
 }

--- a/src/modules/analytics/AnalyticsListener.js
+++ b/src/modules/analytics/AnalyticsListener.js
@@ -25,9 +25,7 @@ export default class AnalyticsListener extends Component<Props> {
   fireAnalyticsEvent: FireAnalyticsEvent = (event, channel) => {
     if (channel === this.props.channel) {
       this.props.onEvent(event);
-    }
-
-    if (this.context.fireAnalyticsEvent) {
+    } else if (this.context.fireAnalyticsEvent) {
       this.context.fireAnalyticsEvent(event, channel);
     }
   }

--- a/src/modules/analytics/AnalyticsListener.js
+++ b/src/modules/analytics/AnalyticsListener.js
@@ -1,18 +1,20 @@
 // @flow
 
-import { Component } from 'react';
+import { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
+import AnalyticsEvent, { type FireAnalyticsEvent } from './AnalyticsEvent';
 
-type AnalyticsListenerProps = {
+type Props = {
+  children?: Node,
   channel: string,
-  onEvent: (event: AnalyticsEventType) => void,
+  onEvent: (event: AnalyticsEvent) => void,
 }
 
 const ContextTypes = {
   fireAnalyticsEvent: PropTypes.func,
 };
 
-export default class AnalyticsListener extends Component<AnalyticsListenerProps> {
+export default class AnalyticsListener extends Component<Props> {
   static contextTypes = ContextTypes
   static childContextTypes = ContextTypes
 
@@ -20,7 +22,7 @@ export default class AnalyticsListener extends Component<AnalyticsListenerProps>
     fireAnalyticsEvent: this.fireAnalyticsEvent,
   })
 
-  fireAnalyticsEvent = (event, channel) => {
+  fireAnalyticsEvent: FireAnalyticsEvent = (event, channel) => {
     if (channel === this.props.channel) {
       this.props.onEvent(event);
     }

--- a/src/modules/analytics/withAnalytics.js
+++ b/src/modules/analytics/withAnalytics.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component, type ComponentType, type ElementType } from 'react';
+import React, { Component, type ComponentType, type ElementConfig } from 'react';
 import PropTypes from 'prop-types';
 
 import AnalyticsEvent, { type RaiseAnalyticsEvent } from './AnalyticsEvent';
@@ -12,16 +12,16 @@ type CallbackPropName = string;
 type RaisedEventHandler = (event: AnalyticsEvent, raise: RaiseAnalyticsEvent) => void;
 type CreateAnalyticsEvent = (name: string, payload?: {}) => AnalyticsEvent;
 
-type CreateEventMethod<T> = (createEvent: CreateAnalyticsEvent, props: T) => AnalyticsEvent;
-type CreateEventMap<T> = {
-  [propCallbackName: string]: string | CreateEventMethod<T>,
+type CreateEventMethod<P> = (createEvent: CreateAnalyticsEvent, props: P) => AnalyticsEvent;
+type CreateEventMap<P> = {
+  [propCallbackName: string]: string | CreateEventMethod<P>,
 }
 
-export type withAnalyticsProps = {
+export type InternalAnalyticsProps = {
   createAnalyticsEvent: CreateAnalyticsEvent,
 }
 
-type Props = {
+type ExternalAnalyticsProps = {
   analyticsNamespace?: string,
   analytics?: {
     [raisedEventName: string]: RenamedEvent | RaisedEventHandler,
@@ -32,176 +32,177 @@ type Props = {
 }
 
 // Tried to get flow typing working but could not :O
-export default (createEventMap: CreateEventMap<*> = {}) => (WrappedComponent: ComponentType<*>): ComponentType<*> =>
-  class WithAnalytics extends Component<*> {
-    static defaultProps = {
-      analyticsNamespace: null,
-      bindEventsToProps: {},
-    };
-
-    static contextTypes = {
-      fireAnalyticsEvent: PropTypes.func,
-      raiseAnalyticsEvent: PropTypes.func,
-      getAnalyticsPath: PropTypes.func,
-    };
-
-    static childContextTypes = {
-      raiseAnalyticsEvent: PropTypes.func,
-      getAnalyticsPath: PropTypes.func,
-    };
-
-    enqueuedEvents = []
-
-    getChildContext = () => ({
-      raiseAnalyticsEvent: this.raiseAnalyticsEvent,
-      getAnalyticsPath: this.getAnalyticsPath,
-    })
-
-    getAnalyticsPath = () => {
-      const { analyticsNamespace } = this.props;
-      const ancestorNamespaces =
-        (typeof this.context.getAnalyticsPath === 'function'
-          && this.context.getAnalyticsPath())
-        || [];
-      return analyticsNamespace
-        ? [...ancestorNamespaces, analyticsNamespace]
-        : ancestorNamespaces;
-    }
-
-    createAnalyticsEvent = (name: string, payload: {} = {}) => {
-      const meta = { path: this.getAnalyticsPath() };
-      const fire = this.context.fireAnalyticsEvent || noop;
-      const raise = this.raiseAnalyticsEvent;
-      return new AnalyticsEvent(name, payload, meta, { fire, raise });
-    }
-
-    raiseAnalyticsEvent = (event: AnalyticsEvent) => {
-      // If this event is bound to a prop callback, defer it and pass it in when
-      // that callback is fired.
-      if (Object.keys(this.props.bindEventsToProps).includes(event.name)) {
-        this.enqueueEvent(event);
-        return;
-      }
-
-      const raise = this.context.raiseAnalyticsEvent || noop;
-      const { analytics: analyticsMap } = this.props;
-
-      // If we don't know or care about this event simply re-raise it.
-      if (!analyticsMap || !analyticsMap[event.name]) {
-        raise(event);
-        return;
-      }
-
-      // If the user has provided a function to handle this event, call it with
-      // the event and the raise function.
-      if (typeof analyticsMap[event.name] === 'function') {
-        analyticsMap[event.name](event, raise);
-      }
-
-      // The user is also allowed to pass a string as the handler. This is
-      // shorthand which tells us to rename the event to the provided string,
-      // then raise the event automatically.
-      if (typeof analyticsMap[event.name] === 'string') {
-        event.rename(analyticsMap[event.name]);
-        raise(event);
-      }
-    }
-
-    enqueueEvent = (event: AnalyticsEvent) => {
-      this.enqueuedEvents = [
-        event,
-        ...this.enqueuedEvents,
-      ];
-    }
-
-    getEnqueuedEvent = (eventName: string) => {
-      const event = this.enqueuedEvents.find(e => e.name === eventName);
-      this.enqueuedEvents = this.enqueuedEvents
-        .filter(e => e.name !== eventName);
-      return event;
-    }
-
-    // Consumers can tell us that certain analytics events are inherently bound
-    // to a callback prop. This means that whenever the event is raised we
-    // should capture it and pass it as an extra argument to that callback prop,
-    // rather than letting the consumer handle the event as normal.
-    bindEventsToProps = (props: Props) => {
-      const bindEventsMap = props.bindEventsToProps;
-      if (!bindEventsMap) {
-        return props;
-      }
-
-      const boundPropCallbacks = Object.keys(bindEventsMap)
-        .reduce((bound, eventName) => {
-          const propName = bindEventsMap[eventName];
-          const providedCallback = props[propName];
-          if (!providedCallback) {
-            return bound;
-          }
-          const boundCallback = (...args) => {
-            const event = this.getEnqueuedEvent(eventName);
-            providedCallback(...args, event);
-          };
-          return {
-            ...bound,
-            [propName]: boundCallback,
-          };
-        }, {});
-
-      return { ...props, ...boundPropCallbacks };
-    }
-
-    // Consumers can provide a map of callbacks to event creators to allow creating events
-    // within certain components.
-    mapCreateEventsToProps = (props: Props) => {
-      if (!createEventMap) {
-        return props;
-      }
-
-      const modifiedPropCallbacks = Object.keys(createEventMap)
-        .reduce((modified, propCallbackName) => {
-          const eventCreator = createEventMap[propCallbackName];
-          const providedCallback = props[propCallbackName];
-          if (!providedCallback) {
-            return modified;
-          }
-          const modifiedCallback = (...args) => {
-            if (typeof eventCreator === 'string') {
-              this.createAnalyticsEvent(eventCreator).raise();
-            } else if (typeof eventCreator === 'function') {
-              eventCreator(this.createAnalyticsEvent, props).raise();
-            } else {
-              console.error('Invalid event creator type passed to withAnalytics event map');
-            }
-            providedCallback(...args);
-          };
-          return {
-            ...modified,
-            [propCallbackName]: modifiedCallback,
-          };
-        }, {});
-
-      return { ...props, ...modifiedPropCallbacks };
-    }
-
-    render() {
-      const patchedProps = this.mapCreateEventsToProps(this.bindEventsToProps(this.props));
-
-      const {
-        analyticsNamespace,
-        analytics,
-        bindEventsToProps,
-        ...permittedProps
-      } = patchedProps;
-
-      const props = {
-        ...permittedProps,
-        ...patchedProps,
-        createAnalyticsEvent: this.createAnalyticsEvent,
+export default <Props: ExternalAnalyticsProps>
+  (createEventMap: CreateEventMap <Props> = { }) => (WrappedComponent: ComponentType<Props>): ComponentType<Props> =>
+    class WithAnalytics extends Component<Props> {
+      static defaultProps = {
+        analyticsNamespace: null,
+        bindEventsToProps: {},
       };
 
-      return (
-        <WrappedComponent {...props} />
-      );
+      static contextTypes = {
+        fireAnalyticsEvent: PropTypes.func,
+        raiseAnalyticsEvent: PropTypes.func,
+        getAnalyticsPath: PropTypes.func,
+      };
+
+      static childContextTypes = {
+        raiseAnalyticsEvent: PropTypes.func,
+        getAnalyticsPath: PropTypes.func,
+      };
+
+      enqueuedEvents = []
+
+      getChildContext = () => ({
+        raiseAnalyticsEvent: this.raiseAnalyticsEvent,
+        getAnalyticsPath: this.getAnalyticsPath,
+      })
+
+      getAnalyticsPath = () => {
+        const { analyticsNamespace } = this.props;
+        const ancestorNamespaces =
+          (typeof this.context.getAnalyticsPath === 'function'
+            && this.context.getAnalyticsPath())
+          || [];
+        return analyticsNamespace
+          ? [...ancestorNamespaces, analyticsNamespace]
+          : ancestorNamespaces;
+      }
+
+      createAnalyticsEvent = (name: string, payload: {} = {}) => {
+        const meta = { path: this.getAnalyticsPath() };
+        const fire = this.context.fireAnalyticsEvent || noop;
+        const raise = this.raiseAnalyticsEvent;
+        return new AnalyticsEvent(name, payload, meta, { fire, raise });
+      }
+
+      raiseAnalyticsEvent = (event: AnalyticsEvent) => {
+        // If this event is bound to a prop callback, defer it and pass it in when
+        // that callback is fired.
+        if (Object.keys(this.props.bindEventsToProps).includes(event.name)) {
+          this.enqueueEvent(event);
+          return;
+        }
+
+        const raise = this.context.raiseAnalyticsEvent || noop;
+        const { analytics: analyticsMap } = this.props;
+
+        // If we don't know or care about this event simply re-raise it.
+        if (!analyticsMap || !analyticsMap[event.name]) {
+          raise(event);
+          return;
+        }
+
+        // If the user has provided a function to handle this event, call it with
+        // the event and the raise function.
+        if (typeof analyticsMap[event.name] === 'function') {
+          analyticsMap[event.name](event, raise);
+        }
+
+        // The user is also allowed to pass a string as the handler. This is
+        // shorthand which tells us to rename the event to the provided string,
+        // then raise the event automatically.
+        if (typeof analyticsMap[event.name] === 'string') {
+          event.rename(analyticsMap[event.name]);
+          raise(event);
+        }
+      }
+
+      enqueueEvent = (event: AnalyticsEvent) => {
+        this.enqueuedEvents = [
+          event,
+          ...this.enqueuedEvents,
+        ];
+      }
+
+      getEnqueuedEvent = (eventName: string) => {
+        const event = this.enqueuedEvents.find(e => e.name === eventName);
+        this.enqueuedEvents = this.enqueuedEvents
+          .filter(e => e.name !== eventName);
+        return event;
+      }
+
+      // Consumers can tell us that certain analytics events are inherently bound
+      // to a callback prop. This means that whenever the event is raised we
+      // should capture it and pass it as an extra argument to that callback prop,
+      // rather than letting the consumer handle the event as normal.
+      bindEventsToProps = (props: Props): Props => {
+        const bindEventsMap = props.bindEventsToProps;
+        if (!bindEventsMap) {
+          return props;
+        }
+
+        const boundPropCallbacks = Object.keys(bindEventsMap)
+          .reduce((bound, eventName) => {
+            const propName = bindEventsMap[eventName];
+            const providedCallback = props[propName];
+            if (!providedCallback) {
+              return bound;
+            }
+            const boundCallback = (...args) => {
+              const event = this.getEnqueuedEvent(eventName);
+              providedCallback(...args, event);
+            };
+            return {
+              ...bound,
+              [propName]: boundCallback,
+            };
+          }, {});
+
+        return (({ ...props, ...boundPropCallbacks }: any): Props);
+      }
+
+      // Consumers can provide a map of callbacks to event creators to allow creating events
+      // within certain components.
+        mapCreateEventsToProps = (props: Props): Props => {
+        if (!createEventMap) {
+          return props;
+        }
+
+        const modifiedPropCallbacks = Object.keys(createEventMap)
+          .reduce((modified, propCallbackName) => {
+            const eventCreator = createEventMap[propCallbackName];
+            const providedCallback = props[propCallbackName];
+            if (!providedCallback) {
+              return modified;
+            }
+            const modifiedCallback = (...args) => {
+              if (typeof eventCreator === 'string') {
+                this.createAnalyticsEvent(eventCreator).raise();
+              } else if (typeof eventCreator === 'function') {
+                eventCreator(this.createAnalyticsEvent, props).raise();
+              } else {
+                console.error('Invalid event creator type passed to withAnalytics event map');
+              }
+              providedCallback(...args);
+            };
+            return {
+              ...modified,
+              [propCallbackName]: modifiedCallback,
+            };
+          }, {});
+
+        return (({ ...props, ...modifiedPropCallbacks }: any): Props);
+      }
+
+      render() {
+        const patchedProps = this.mapCreateEventsToProps(this.bindEventsToProps(this.props));
+
+        const {
+          analyticsNamespace,
+          analytics,
+          bindEventsToProps,
+          ...permittedProps
+        } = patchedProps;
+
+        const props = {
+          ...permittedProps,
+          ...patchedProps,
+          createAnalyticsEvent: this.createAnalyticsEvent,
+        };
+
+        return (
+          <WrappedComponent {...props} />
+        );
+      }
     }
-  }

--- a/src/modules/analytics/withAnalytics.js
+++ b/src/modules/analytics/withAnalytics.js
@@ -10,8 +10,12 @@ const noop = (...args: any) => {};
 type RenamedEvent = string;
 type CallbackPropName = string;
 type RaisedEventHandler = (event: AnalyticsEvent, raise: RaiseAnalyticsEvent) => void;
-
 type CreateAnalyticsEvent = (name: string, payload?: {}) => AnalyticsEvent;
+
+type CreateEventMethod<T> = (createEvent: CreateAnalyticsEvent, props: T) => AnalyticsEvent;
+type CreateEventMap<T> = {
+  [propCallbackName: string]: string | CreateEventMethod<T>,
+}
 
 export type withAnalyticsProps = {
   createAnalyticsEvent: CreateAnalyticsEvent,
@@ -27,11 +31,6 @@ type Props = {
   },
 }
 
-type CreateEventMethod<T> = (createEvent: CreateAnalyticsEvent, props: T) => AnalyticsEvent;
-
-type CreateEventMap<T> = {
-  [propCallbackName: string]: string | CreateEventMethod<T>,
-}
 
 export default (WrappedComponent: ComponentType<Props>, createEventMap: CreateEventMap<Props> = {}) =>
   class WithAnalytics extends Component<Props> {
@@ -148,7 +147,7 @@ export default (WrappedComponent: ComponentType<Props>, createEventMap: CreateEv
             [propName]: boundCallback,
           };
         }, {});
-      
+
       return { ...props, ...boundPropCallbacks };
     }
 

--- a/src/modules/analytics/withAnalytics.js
+++ b/src/modules/analytics/withAnalytics.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component, type ComponentType } from 'react';
+import React, { Component, type ComponentType, type ElementType } from 'react';
 import PropTypes from 'prop-types';
 
 import AnalyticsEvent, { type RaiseAnalyticsEvent } from './AnalyticsEvent';
@@ -22,18 +22,18 @@ export type withAnalyticsProps = {
 }
 
 type Props = {
-  analyticsNamespace: string,
+  analyticsNamespace?: string,
   analytics?: {
     [raisedEventName: string]: RenamedEvent | RaisedEventHandler,
   },
-  bindEventsToProps: {
+  bindEventsToProps?: {
     [eventName: string]: CallbackPropName,
   },
 }
 
-
-export default (WrappedComponent: ComponentType<Props>, createEventMap: CreateEventMap<Props> = {}) =>
-  class WithAnalytics extends Component<Props> {
+// Tried to get flow typing working but could not :O
+export default (createEventMap: CreateEventMap<*> = {}) => (WrappedComponent: ComponentType<*>): ComponentType<*> =>
+  class WithAnalytics extends Component<*> {
     static defaultProps = {
       analyticsNamespace: null,
       bindEventsToProps: {},
@@ -204,4 +204,4 @@ export default (WrappedComponent: ComponentType<Props>, createEventMap: CreateEv
         <WrappedComponent {...props} />
       );
     }
-  };
+  }

--- a/src/modules/button/index.js
+++ b/src/modules/button/index.js
@@ -28,14 +28,14 @@ class Button extends Component<ButtonProps> {
   }
 }
 
-export default withAnalytics(Button, {
+export default withAnalytics({
   onClick: 'click',
-});
+})(Button);
 
-export const ButtonWithCreateEventCallback = withAnalytics(Button, {
+export const ButtonWithCreateEventCallback = withAnalytics({
   onClick: (createEvent, props) => createEvent('click', {
     createdWithCustomFn: true,
     myOwnNamespace: props.analyticsNamespace,
     allProps: props,
   })
-});
+})(Button);

--- a/src/modules/button/index.js
+++ b/src/modules/button/index.js
@@ -3,11 +3,15 @@
 import React, { Component } from 'react';
 
 import { withAnalytics } from '../analytics';
+import { type withAnalyticsProps } from '../analytics/withAnalytics';
 
-class Button extends Component<*> {
+type ButtonProps = {
+  onClick: (e: MouseEvent) => void,
+} & withAnalyticsProps;
+
+class Button extends Component<ButtonProps> {
   handleClick = e => {
     const { createAnalyticsEvent } = this.props;
-    createAnalyticsEvent('click').raise();
     createAnalyticsEvent(
       'atlaskit-button-click',
       { version: '1.0.0' }
@@ -24,4 +28,6 @@ class Button extends Component<*> {
   }
 }
 
-export default withAnalytics(Button);
+export default withAnalytics(Button, {
+  onClick: 'click',
+});

--- a/src/modules/button/index.js
+++ b/src/modules/button/index.js
@@ -3,11 +3,11 @@
 import React, { Component } from 'react';
 
 import { withAnalytics } from '../analytics';
-import { type withAnalyticsProps } from '../analytics/withAnalytics';
+import { type InternalAnalyticsProps } from '../analytics/withAnalytics';
 
 type ButtonProps = {
   onClick: (e: MouseEvent) => void,
-} & withAnalyticsProps;
+} & InternalAnalyticsProps;
 
 class Button extends Component<ButtonProps> {
   handleClick = e => {
@@ -38,4 +38,8 @@ export const ButtonWithCreateEventCallback = withAnalytics({
     myOwnNamespace: props.analyticsNamespace,
     allProps: props,
   })
+})(Button);
+
+export const ButtonFireOnly = withAnalytics({
+  onClick: (createEvent) => createEvent('click').fire(),
 })(Button);

--- a/src/modules/button/index.js
+++ b/src/modules/button/index.js
@@ -31,3 +31,11 @@ class Button extends Component<ButtonProps> {
 export default withAnalytics(Button, {
   onClick: 'click',
 });
+
+export const ButtonWithCreateEventCallback = withAnalytics(Button, {
+  onClick: (createEvent, props) => createEvent('click', {
+    createdWithCustomFn: true,
+    myOwnNamespace: props.analyticsNamespace,
+    allProps: props,
+  })
+});

--- a/src/modules/checkbox/index.js
+++ b/src/modules/checkbox/index.js
@@ -1,0 +1,15 @@
+// @flow
+
+import React from 'react';
+import { withAnalytics } from '../analytics';
+
+type Props = {
+  checked: boolean,
+  onChange: (e: MouseEvent) => void,
+};
+
+const Input = ({ ...props }: Props ) => (<input type="checkbox" {...props} />);
+
+export default withAnalytics({
+  onChange: (createEvent, props) => createEvent('change', { checked: !props.checked }),
+})(Input);


### PR DESCRIPTION
There are two API changes here:

1. Binding events are now achieved via a prop instead of a param to the withAnalytics HOC. This makes it easier to bind events without creating new components.

2. Events can be created on certain prop callbacks now via a map passed as the 2nd param to the withAnalytics HOC, similar to the old withAnalytics implementation.