### PR TITLE
Polish

### DIFF
--- a/src/components/Issue.js
+++ b/src/components/Issue.js
@@ -20,7 +20,9 @@ const mockReduxAddCommentAction = async analyticsEvent => {
   const commentId = await new Promise(resolve =>
     window.setTimeout(() => resolve(Math.round(Math.random() * 1000)), 1000),
   );
-  analyticsEvent.update({ commentId }).fire('jira');
+  analyticsEvent
+    .update({ action: 'comment-create-successful', commentId })
+    .fire('jira');
 };
 
 export default class Issue extends Component<Props, State> {
@@ -30,6 +32,11 @@ export default class Issue extends Component<Props, State> {
   };
 
   addComment = (e: Event, analyticsEvent: UIAnalyticsEvent) => {
+    analyticsEvent.update(payload => ({
+      ...payload,
+      originalAction: payload.action,
+      action: 'comment-create-requested',
+    }));
     const pessimisticAnalyticsEvent = analyticsEvent.clone();
     analyticsEvent.fire('jira');
     mockReduxAddCommentAction(pessimisticAnalyticsEvent);
@@ -47,7 +54,7 @@ export default class Issue extends Component<Props, State> {
 
   onEvent = (event: UIAnalyticsEvent, field: string) => {
     const { issueId } = this.props;
-    event.update({ field, issueId }).fire('jira');
+    event.update({ action: 'issue-updated', field, issueId }).fire('jira');
   };
 
   render() {

--- a/src/modules/analytics/AnalyticsContext.js
+++ b/src/modules/analytics/AnalyticsContext.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import type { ObjectType } from './types';
 
 const ContextTypes = {
-  getAnalyticsContext: PropTypes.func,
+  getAtlaskitAnalyticsContext: PropTypes.func,
 };
 
 type Props = {
@@ -20,14 +20,15 @@ export default class AnalyticsContext extends Component<Props> {
   static childContextTypes = ContextTypes;
 
   getChildContext = () => ({
-    getAnalyticsContext: this.getAnalyticsContext,
+    getAtlaskitAnalyticsContext: this.getAnalyticsContext,
   });
 
   getAnalyticsContext = () => {
     const { data } = this.props;
-    const { getAnalyticsContext } = this.context;
+    const { getAtlaskitAnalyticsContext } = this.context;
     const ancestorData =
-      (typeof getAnalyticsContext === 'function' && getAnalyticsContext()) ||
+      (typeof getAtlaskitAnalyticsContext === 'function' &&
+        getAtlaskitAnalyticsContext()) ||
       [];
     return [...ancestorData, data];
   };

--- a/src/modules/analytics/AnalyticsEvent.js
+++ b/src/modules/analytics/AnalyticsEvent.js
@@ -9,18 +9,15 @@ import type {
 } from './types';
 
 export default class AnalyticsEvent implements AnalyticsEventInterface {
-  action: string;
   payload: {};
 
   constructor(props: AnalyticsEventProps) {
-    this.action = props.action;
     this.payload = props.payload;
   }
 
   clone = (): AnalyticsEvent => {
-    const action = this.action;
     const payload = cloneDeep(this.payload);
-    return new AnalyticsEvent({ action, payload });
+    return new AnalyticsEvent({ payload });
   };
 
   update(updater: AnalyticsEventUpdater): this {

--- a/src/modules/analytics/AnalyticsListener.js
+++ b/src/modules/analytics/AnalyticsListener.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const ContextTypes = {
-  getAnalyticsEventHandlers: PropTypes.func,
+  getAtlaskitAnalyticsEventHandlers: PropTypes.func,
 };
 
 export default class AnalyticsListener extends Component<Props, void> {
@@ -20,15 +20,15 @@ export default class AnalyticsListener extends Component<Props, void> {
   static childContextTypes = ContextTypes;
 
   getChildContext = () => ({
-    getAnalyticsEventHandlers: this.getAnalyticsEventHandlers,
+    getAtlaskitAnalyticsEventHandlers: this.getAnalyticsEventHandlers,
   });
 
   getAnalyticsEventHandlers = () => {
     const { channel, onEvent } = this.props;
-    const { getAnalyticsEventHandlers } = this.context;
+    const { getAtlaskitAnalyticsEventHandlers } = this.context;
     const parentEventHandlers =
-      (typeof getAnalyticsEventHandlers === 'function' &&
-        getAnalyticsEventHandlers()) ||
+      (typeof getAtlaskitAnalyticsEventHandlers === 'function' &&
+        getAtlaskitAnalyticsEventHandlers()) ||
       [];
     const handler: UIAnalyticsEventHandlerSignature = (event, eventChannel) => {
       if (channel === '*' || channel === eventChannel) {

--- a/src/modules/analytics/UIAnalyticsEvent.js
+++ b/src/modules/analytics/UIAnalyticsEvent.js
@@ -33,11 +33,10 @@ export default class UIAnalyticsEvent extends AnalyticsEvent
       warn("Cannot clone an event after it's been fired.");
       return null;
     }
-    const action = this.action;
     const context = [...this.context];
     const handlers = [...this.handlers];
     const payload = cloneDeep(this.payload);
-    return new UIAnalyticsEvent({ action, context, handlers, payload });
+    return new UIAnalyticsEvent({ context, handlers, payload });
   };
 
   fire = (channel?: string) => {

--- a/src/modules/analytics/index.js
+++ b/src/modules/analytics/index.js
@@ -14,6 +14,6 @@ export { default as withAnalyticsContext } from './withAnalyticsContext';
 
 // createAnalyticsEvent HOC
 export {
-  default as withCreateAnalyticsEvent,
-  WithCreateAnalyticsEventProps,
-} from './withCreateAnalyticsEvent';
+  default as withAnalyticsEvents,
+  WithAnalyticsEventsProps,
+} from './withAnalyticsEvents';

--- a/src/modules/analytics/types.js
+++ b/src/modules/analytics/types.js
@@ -14,12 +14,10 @@ export type AnalyticsEventUpdater =
   | ((payload: AnalyticsEventPayload) => AnalyticsEventPayload);
 
 export type AnalyticsEventProps = {
-  action: string,
   payload: {},
 };
 
 export interface AnalyticsEventInterface {
-  action: string;
   payload: AnalyticsEventPayload;
 
   clone: () => AnalyticsEvent;
@@ -40,7 +38,6 @@ export type UIAnalyticsEventProps = AnalyticsEventProps & {
 };
 
 export interface UIAnalyticsEventInterface {
-  action: string;
   context: Array<ObjectType>;
   handlers?: Array<UIAnalyticsEventHandlerSignature>;
   hasFired: boolean;

--- a/src/modules/analytics/withAnalyticsContext.js
+++ b/src/modules/analytics/withAnalyticsContext.js
@@ -11,13 +11,14 @@ export default function withAnalyticsContext<ProvidedProps: ObjectType>(
   return (WrappedComponent: ComponentType<ProvidedProps>) =>
     class WithAnalyticsContext extends Component<ProvidedProps> {
       static defaultProps = {
-        analyticsContext: defaultData,
+        analyticsContext: {},
       };
 
       render() {
         const { analyticsContext, ...props } = this.props;
+        const data = { ...defaultData, ...analyticsContext };
         return (
-          <AnalyticsContext data={analyticsContext}>
+          <AnalyticsContext data={data}>
             <WrappedComponent {...props} />
           </AnalyticsContext>
         );

--- a/src/modules/analytics/withAnalyticsContext.js
+++ b/src/modules/analytics/withAnalyticsContext.js
@@ -5,11 +5,11 @@ import React, { Component, type ComponentType } from 'react';
 import AnalyticsContext from './AnalyticsContext';
 import type { ObjectType } from './types';
 
-export default function withAnalyticsNamespace<ProvidedProps: ObjectType>(
+export default function withAnalyticsContext<ProvidedProps: ObjectType>(
   defaultData?: ObjectType = {},
 ) {
   return (WrappedComponent: ComponentType<ProvidedProps>) =>
-    class WithAnalyticsNamespace extends Component<ProvidedProps> {
+    class WithAnalyticsContext extends Component<ProvidedProps> {
       static defaultProps = {
         analyticsContext: defaultData,
       };

--- a/src/modules/analytics/withAnalyticsEvents.js
+++ b/src/modules/analytics/withAnalyticsEvents.js
@@ -7,7 +7,6 @@ import UIAnalyticsEvent from './UIAnalyticsEvent';
 import type { AnalyticsEventPayload, ObjectType } from './types';
 
 export type CreateUIAnalyticsEventSignature = (
-  name: string,
   payload?: AnalyticsEventPayload,
 ) => UIAnalyticsEvent;
 
@@ -17,7 +16,7 @@ export type WithAnalyticsEventsProps = {
 
 type EventMap<ProvidedProps> = {
   [string]:
-    | string
+    | ObjectType
     | ((
         create: CreateUIAnalyticsEventSignature,
         props: ProvidedProps,
@@ -34,10 +33,7 @@ export default function withAnalyticsEvents<ProvidedProps: ObjectType>(
         getAtlaskitAnalyticsContext: PropTypes.func,
       };
 
-      createAnalyticsEvent = (
-        action: string,
-        payload?: ObjectType = {},
-      ): UIAnalyticsEvent => {
+      createAnalyticsEvent = (payload?: ObjectType = {}): UIAnalyticsEvent => {
         const {
           getAtlaskitAnalyticsEventHandlers,
           getAtlaskitAnalyticsContext,
@@ -50,7 +46,7 @@ export default function withAnalyticsEvents<ProvidedProps: ObjectType>(
           (typeof getAtlaskitAnalyticsEventHandlers === 'function' &&
             getAtlaskitAnalyticsEventHandlers()) ||
           [];
-        return new UIAnalyticsEvent({ action, context, handlers, payload });
+        return new UIAnalyticsEvent({ context, handlers, payload });
       };
 
       mapCreateEventsToProps = () => {
@@ -60,7 +56,7 @@ export default function withAnalyticsEvents<ProvidedProps: ObjectType>(
             const providedCallback = this.props[propCallbackName];
             if (
               !providedCallback ||
-              !['string', 'function'].includes(typeof eventCreator)
+              !['object', 'function'].includes(typeof eventCreator)
             ) {
               return modified;
             }

--- a/src/modules/analytics/withAnalyticsEvents.js
+++ b/src/modules/analytics/withAnalyticsEvents.js
@@ -11,7 +11,7 @@ export type CreateUIAnalyticsEventSignature = (
   payload?: AnalyticsEventPayload,
 ) => UIAnalyticsEvent;
 
-export type WithCreateAnalyticsEventProps = {
+export type WithAnalyticsEventsProps = {
   createAnalyticsEvent: CreateUIAnalyticsEventSignature,
 };
 
@@ -24,11 +24,11 @@ type EventMap<ProvidedProps> = {
       ) => UIAnalyticsEvent | void),
 };
 
-export default function withCreateAnalyticsEvent<ProvidedProps: ObjectType>(
+export default function withAnalyticsEvents<ProvidedProps: ObjectType>(
   createEventMap: EventMap<ProvidedProps> = {},
 ) {
   return (WrappedComponent: ComponentType<ProvidedProps>) =>
-    class WithCreateAnalyticsEvent extends Component<ProvidedProps> {
+    class WithAnalyticsEvents extends Component<ProvidedProps> {
       static contextTypes = {
         getAnalyticsEventHandlers: PropTypes.func,
         getAnalyticsContext: PropTypes.func,

--- a/src/modules/analytics/withAnalyticsEvents.js
+++ b/src/modules/analytics/withAnalyticsEvents.js
@@ -30,22 +30,25 @@ export default function withAnalyticsEvents<ProvidedProps: ObjectType>(
   return (WrappedComponent: ComponentType<ProvidedProps>) =>
     class WithAnalyticsEvents extends Component<ProvidedProps> {
       static contextTypes = {
-        getAnalyticsEventHandlers: PropTypes.func,
-        getAnalyticsContext: PropTypes.func,
+        getAtlaskitAnalyticsEventHandlers: PropTypes.func,
+        getAtlaskitAnalyticsContext: PropTypes.func,
       };
 
       createAnalyticsEvent = (
         action: string,
         payload?: ObjectType = {},
       ): UIAnalyticsEvent => {
-        const { getAnalyticsEventHandlers, getAnalyticsContext } = this.context;
+        const {
+          getAtlaskitAnalyticsEventHandlers,
+          getAtlaskitAnalyticsContext,
+        } = this.context;
         const context =
-          (typeof getAnalyticsContext === 'function' &&
-            getAnalyticsContext()) ||
+          (typeof getAtlaskitAnalyticsContext === 'function' &&
+            getAtlaskitAnalyticsContext()) ||
           [];
         const handlers =
-          (typeof getAnalyticsEventHandlers === 'function' &&
-            getAnalyticsEventHandlers()) ||
+          (typeof getAtlaskitAnalyticsEventHandlers === 'function' &&
+            getAtlaskitAnalyticsEventHandlers()) ||
           [];
         return new UIAnalyticsEvent({ action, context, handlers, payload });
       };

--- a/src/modules/analytics/withCreateAnalyticsEvent.js
+++ b/src/modules/analytics/withCreateAnalyticsEvent.js
@@ -39,8 +39,14 @@ export default function withCreateAnalyticsEvent<ProvidedProps: ObjectType>(
         payload?: ObjectType = {},
       ): UIAnalyticsEvent => {
         const { getAnalyticsEventHandlers, getAnalyticsContext } = this.context;
-        const context = getAnalyticsContext() || [];
-        const handlers = getAnalyticsEventHandlers();
+        const context =
+          (typeof getAnalyticsContext === 'function' &&
+            getAnalyticsContext()) ||
+          [];
+        const handlers =
+          (typeof getAnalyticsEventHandlers === 'function' &&
+            getAnalyticsEventHandlers()) ||
+          [];
         return new UIAnalyticsEvent({ action, context, handlers, payload });
       };
 

--- a/src/modules/button/index.js
+++ b/src/modules/button/index.js
@@ -22,8 +22,8 @@ class Button extends Component<Props, void> {
 export default withAnalyticsContext({ namespace: 'button' })(
   withAnalyticsEvents({
     onClick: createEvent => {
-      createEvent('click', { version: '1.0.0' }).fire('atlaskit');
-      return createEvent('click');
+      createEvent({ action: 'click', version: '1.0.0' }).fire('atlaskit');
+      return createEvent({ action: 'click' });
     },
   })(Button),
 );

--- a/src/modules/button/index.js
+++ b/src/modules/button/index.js
@@ -4,11 +4,11 @@ import React, { Component } from 'react';
 
 import {
   withAnalyticsContext,
-  withCreateAnalyticsEvent,
-  type WithCreateAnalyticsEventProps,
+  withAnalyticsEvents,
+  type WithAnalyticsEventsProps,
 } from '../analytics';
 
-type Props = WithCreateAnalyticsEventProps & {
+type Props = WithAnalyticsEventsProps & {
   onClick: (e: MouseEvent) => void,
 };
 
@@ -20,7 +20,7 @@ class Button extends Component<Props, void> {
 }
 
 export default withAnalyticsContext({ namespace: 'button' })(
-  withCreateAnalyticsEvent({
+  withAnalyticsEvents({
     onClick: createEvent => {
       createEvent('click', { version: '1.0.0' }).fire('atlaskit');
       return createEvent('click');

--- a/src/modules/checkbox/index.js
+++ b/src/modules/checkbox/index.js
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import {
-  withCreateAnalyticsEvent,
-  type WithCreateAnalyticsEventProps,
+  withAnalyticsEvents,
+  type WithAnalyticsEventsProps,
 } from '../analytics';
 
-type Props = WithCreateAnalyticsEventProps & {
+type Props = WithAnalyticsEventsProps & {
   checked: boolean,
   onChange: (e: MouseEvent) => void,
 };
@@ -15,7 +15,7 @@ const Input = ({ createAnalyticsEvent, ...props }: Props) => (
   <input type="checkbox" {...props} />
 );
 
-export default withCreateAnalyticsEvent({
+export default withAnalyticsEvents({
   onChange: (createEvent, props) =>
     createEvent('change', { checked: !props.checked }),
 })(Input);

--- a/src/modules/checkbox/index.js
+++ b/src/modules/checkbox/index.js
@@ -17,5 +17,5 @@ const Input = ({ createAnalyticsEvent, ...props }: Props) => (
 
 export default withAnalyticsEvents({
   onChange: (createEvent, props) =>
-    createEvent('change', { checked: !props.checked }),
+    createEvent({ action: 'change', checked: !props.checked }),
 })(Input);

--- a/src/modules/checkbox/index.js
+++ b/src/modules/checkbox/index.js
@@ -7,7 +7,7 @@ import {
 } from '../analytics';
 
 type Props = WithAnalyticsEventsProps & {
-  checked: boolean,
+  defaultChecked: boolean,
   onChange: (e: MouseEvent) => void,
 };
 
@@ -16,6 +16,9 @@ const Input = ({ createAnalyticsEvent, ...props }: Props) => (
 );
 
 export default withAnalyticsEvents({
-  onChange: (createEvent, props) =>
-    createEvent({ action: 'change', checked: !props.checked }),
+  onChange: (createEvent, props) => {
+    createEvent({ action: 'change', checked: !props.defaultChecked }).fire(
+      'atlaskit',
+    );
+  },
 })(Input);

--- a/src/sendAnalyticsEventToBackend.js
+++ b/src/sendAnalyticsEventToBackend.js
@@ -26,7 +26,7 @@ export default (event: UIAnalyticsEvent, channel?: string = 'NULL CHANNEL') => {
     };
 
     const toClient = {
-      action: event.action,
+      action: event.payload.action || '',
       actionSubject,
       actionSubjectId,
       attributes,
@@ -39,7 +39,7 @@ export default (event: UIAnalyticsEvent, channel?: string = 'NULL CHANNEL') => {
   } else {
     // Event was created outside the UI
     const toClient = {
-      action: event.action,
+      action: event.payload.action || '',
       attributes: event.payload,
     };
     console.group('RECEIVED GENERIC EVENT:');


### PR DESCRIPTION
✅ fixed errors when there are no listeners or context when an event is created
✅ renamed withCreateAnalyticsEvent to withAnalyticsEvents
✅ renamed keys on context to be more unique
✅ removed action property from events and add examples demonstrating how it's better for this to be part of the payload
✅ withAnalyticsContext shallow merges defaultData with analyticsContext prop, rather than completely overwriting it
✅ create event map => props is only calculated once rather than on every render